### PR TITLE
Add initial docs & templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,61 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+labels: bug
+
+---
+
+## Bug Description
+
+<!-- Please describe clearly and concisely what the bug is. -->
+
+## Expected Behaviour
+
+<!-- Please describe clearly and concisely what the expected behaviour should be. -->
+
+## Steps to reproduce
+
+<!-- Please provide detailed steps on how to reproduce the bug. Provide a URL where the issue can be seen on the frontend when possible. -->
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Screenshots
+
+<!-- If applicable, please add screenshots to help explain your problem. Bonus points for videos! -->
+
+## Additional context
+
+<!-- Please complete the following information. -->
+- Project version:
+- Node version:
+- OS:
+- Browser: [e.g. chrome, safari]
+- Device: [e.g. iPhone12]
+
+<!-- Please add any additional information about the bug. -->
+
+---------------
+
+_Do not alter or remove anything below. The following sections will be managed by moderators only._
+
+## Acceptance criteria
+
+* <!-- One or more bullet points for acceptance criteria. -->
+
+## Implementation brief
+
+* <!-- One or more bullet points for how to technically resolve the issue. For significant Implementation Design, it is ok use a Google document **accessible by anyone**. -->
+
+## QA testing instructions
+
+* <!-- One or more bullet points to describe how to test the implementation in QA. -->
+
+## Demo
+
+* <!-- A video or screenshots demoing the implementation. -->
+
+## Changelog entry
+
+* <!-- One sentence summarizing the PR, to be used in the changelog. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: ✨ Feature request
+about: Suggest an idea for this project
+labels: enhancement
+
+---
+
+## Feature description
+
+<!-- Please describe clear and concisely which problem the feature would solves. -->
+
+---------------
+
+_Do not alter or remove anything below. The following sections will be managed by moderators only._
+
+## Acceptance criteria
+
+* <!-- One or more bullet points for acceptance criteria. -->
+
+## Implementation brief
+
+* <!-- One or more bullet points for how to technically resolve the issue. For significant Implementation Design, it is ok use a Google document **accessible by anyone**. -->
+
+## QA testing instructions
+
+* <!-- One or more bullet points to describe how to test the implementation in QA. -->
+
+## Demo
+
+* <!-- A video or screenshots demoing the implementation. -->
+
+## Changelog entry
+
+* <!-- One sentence summarizing the PR, to be used in the changelog. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- Please reference the issue(s) this PR fixes. -->
+Fixes #
+
+## Checklist
+
+- [ ] My pull request is addressing an [open issue](https://github.com/xwp/web-dev-media/issues) (please create one otherwise).
+- [ ] My code is tested and passes existing [tests](https://github.com/xwp/web-dev-media/ENGINEERING.md#tests).
+- [ ] My code follows the [Contributing Guidelines](https://github.com/xwp/web-dev-media/CONTRIBUTING.md) (updates are often made to the guidelines, check it out periodically).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or 
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when the Project
+Steward has a reasonable belief that an individual's behavior may have a
+negative impact on the project or its community.
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement
+often yield positive results. However, it is never okay to be disrespectful or
+to engage in behavior that violates the project’s code of conduct.
+
+If you see someone violating the code of conduct, you are encouraged to address
+the behavior directly with those involved. Many issues can be resolved quickly
+and easily, and this gives people more control over the outcome of their
+dispute. If you are unable to resolve the matter for any reason, or if the
+behavior is threatening or harassing, report it. We are dedicated to providing
+an environment where participants feel welcome and safe.
+
+Reports should be directed to *[PROJECT STEWARD NAME(s) AND EMAIL(s)]*, the
+Project Steward(s) for *[PROJECT NAME]*. It is the Project Steward’s duty to
+receive and address reported violations of the code of conduct. They will then
+work with a committee consisting of representatives from the Open Source
+Programs Office and the Google Open Source Strategy team. If for any reason you
+are uncomfortable reaching out the Project Steward, please email
+opensource@google.com.
+
+We will investigate every complaint, but you may not receive a direct response.
+We will use our discretion in determining when and how to follow up on reported
+incidents, which may range from not taking action to permanent expulsion from
+the project and project-sponsored spaces. We will notify the accused of the
+report and provide them an opportunity to discuss it before any action is taken.
+The identity of the reporter will be omitted from the details of the report
+supplied to the accused. In potentially harmful situations, such as ongoing
+harassment or threats to anyone's safety, we may take action without notice.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
+available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing Guide
+
+@todo

--- a/ENGINEERING.md
+++ b/ENGINEERING.md
@@ -1,0 +1,7 @@
+# Engineering Guide
+
+@todo
+
+## Tests
+
+@todo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Disclosures
+
+This project accepts responsible security disclosures through the [Google Application Security program](https://www.google.com/about/appsecurity/).


### PR DESCRIPTION
This PR is the first pass for the project docs and then gets the templates added for issues and PRs. I've left the contributing and engineering guides empty for now, we can circle back later. This PR is mainly to get the templates in place so we can setup the project board and start to move stories over from the Google Sheet.