### PR TITLE
Add a getAll method to the IDB meta helper.

### DIFF
--- a/src/js/modules/IDBConnection.module.js
+++ b/src/js/modules/IDBConnection.module.js
@@ -25,6 +25,19 @@ const metaAccessorFactory = (abstractedIDB) => ({
     return data;
   },
 
+  async getAll() {
+    const transaction = abstractedIDB.db.transaction([this.name], 'readonly');
+    const store = transaction.objectStore(this.name);
+    const data = await new Promise((resolve, reject) => {
+      const request = store.getAll();
+
+      request.onsuccess = (e) => resolve(e.target.result);
+      request.onerror = () => reject('Unable to fetch meta information.');
+    });
+
+    return data;
+  },
+
   async put(videoMetaData) {
     return abstractedIDB.defaultAccesor.put(videoMetaData, this.name);
   },


### PR DESCRIPTION
## Summary

Adds a `getAll` method to the offline IDB helper that retrieves all downloaded video metadata.

**Usage:**

```js
const idbConnection = await IDBConnection.getConnection();
const allMeta = await db.meta.getAll();
```

**Returned values:**

```js
[
  {
    done: true,
    mime: "video/mp4",
    offset: 2299653,
    sizeInBytes: 2299653,
    url: "..."
  },
  { ... },
  { ... }
]
```