### PR TITLE
Pre-cache api.json for offline use

### DIFF
--- a/src/js/sw/cache.js
+++ b/src/js/sw/cache.js
@@ -1,5 +1,6 @@
 export default [
   '/',
+  '/api.json',
   '/dist/js/index.js',
   '/images/apple-touch-icon.png',
   '/images/arrow-down.svg',

--- a/src/js/utils/generateAssetsToCache.js
+++ b/src/js/utils/generateAssetsToCache.js
@@ -30,7 +30,7 @@ export default async function generateAssetsToCache(api) {
   const start = Date.now();
   const filesRegExp = /\.(html|css|js|svg|png|jpeg|jpg|ico)$/i;
   const excludeFiles = ['sw.js', '404.html'];
-  const assetsToCache = ['/'];
+  const assetsToCache = ['/', '/api.json'];
   const folder = 'public';
 
   // eslint-disable-next-line


### PR DESCRIPTION
## Summary

Adds `api.json` to the pre-cache array so the homepage can properly load while offline.
<!-- Please reference the issue(s) this PR fixes. -->
Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/web-dev-media/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/xwp/web-dev-media/ENGINEERING.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/xwp/web-dev-media/CONTRIBUTING.md) (updates are often made to the guidelines, check it out periodically).
