### PR TITLE
Display correct quota info in supported browsers.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,11 +88,15 @@ const router = new Router({
   videoDownloaderRegistry,
   connectionStatus,
 });
-router.route('/', HomePage);
-router.route('/settings', SettingsPage);
-router.route('/downloads', DownloadsPage);
-router.route(RegExp('/category/(.*)'), CategoryPage);
-router.route('*', VideoPage);
+router.route('^/settings/?', SettingsPage);
+router.route('^/downloads/?', DownloadsPage);
+router.route('^/category/([^/]*)/?', CategoryPage);
+router.route('^/?$', HomePage);
+
+/**
+ * Consider all else a single video page.
+ */
+router.route('.*', VideoPage);
 
 /**
  * Register Service Worker.

--- a/src/js/components/VideoDownloader/StorageManager.module.js
+++ b/src/js/components/VideoDownloader/StorageManager.module.js
@@ -52,21 +52,30 @@ export default class {
 
     const metaWritePromise = new Promise((resolve, reject) => {
       const metaPutOperation = db.meta.put(videoMeta);
-      metaPutOperation.onsuccess = resolve;
+      metaPutOperation.onsuccess = () => {
+        db.dispatchDataChangedEvent();
+        resolve();
+      };
       metaPutOperation.onerror = reject;
     });
 
     const dataWritePromise = new Promise((resolve, reject) => {
       const dataPutOperation = db.data.put(fileChunk);
 
-      dataPutOperation.onsuccess = resolve;
+      dataPutOperation.onsuccess = () => {
+        db.dispatchDataChangedEvent();
+        resolve();
+      };
       dataPutOperation.onerror = reject;
     });
 
     const fileWritePromise = new Promise((resolve, reject) => {
       const dataPutOperation = db.file.put(fileMeta);
 
-      dataPutOperation.onsuccess = resolve;
+      dataPutOperation.onsuccess = () => {
+        db.dispatchDataChangedEvent();
+        resolve();
+      };
       dataPutOperation.onerror = reject;
     });
 

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -102,3 +102,8 @@ export const ALL_STREAM_TYPES = ['audio', 'video'];
  * Settings key names.
  */
 export const SETTING_KEY_TOGGLE_OFFLINE = 'toggle-offline';
+
+/**
+ * Event name signalling that data in IDB has changes.
+ */
+export const IDB_DATA_CHANGED_EVENT = 'idb-data-changed';

--- a/src/js/modules/IDBConnection.module.js
+++ b/src/js/modules/IDBConnection.module.js
@@ -1,6 +1,7 @@
 import {
   STORAGE_SCHEMA,
   IDB_CHUNK_INDEX,
+  IDB_DATA_CHANGED_EVENT,
 } from '../constants';
 
 const dbName = 'webdev-offline-storage';
@@ -153,6 +154,15 @@ export default () => {
         };
       }
 
+      /**
+       * Dispatch an event signalling that data in IDB
+       * has changed.
+       */
+      dispatchDataChangedEvent() {
+        const changeEvent = new Event(IDB_DATA_CHANGED_EVENT);
+        window.dispatchEvent(changeEvent);
+      }
+
       unwrap() {
         return this.db;
       }
@@ -177,7 +187,10 @@ export default () => {
       dataStore.clear();
       fileStore.clear();
 
-      transaction.oncomplete = () => resolve();
+      transaction.oncomplete = () => {
+        abstractedIDB.dispatchDataChangedEvent();
+        resolve();
+      };
       transaction.onerror = () => reject();
     });
 
@@ -228,7 +241,10 @@ export default () => {
       );
       metaStore.delete(id);
 
-      transaction.oncomplete = () => resolve();
+      transaction.oncomplete = () => {
+        abstractedIDB.dispatchDataChangedEvent();
+        resolve();
+      };
       transaction.onerror = () => reject();
     });
 

--- a/src/js/pages/Downloads.js
+++ b/src/js/pages/Downloads.js
@@ -1,3 +1,4 @@
+import { IDB_DATA_CHANGED_EVENT } from '../constants';
 import getIDBConnection from '../modules/IDBConnection.module';
 import getDownloaderElement from '../utils/getDownloaderElement.module';
 
@@ -44,6 +45,27 @@ export default async (routerContext) => {
   const deleteAllBtn = mainContent.querySelector('.delete-all');
   const grid = mainContent.querySelector('.grid');
 
+  /**
+   * Displays the current storage quota.
+   */
+  const displayQuota = () => {
+    if (navigator.storage?.estimate) {
+      navigator.storage.estimate().then(
+        (quota) => {
+          const quotaElement = mainContent.querySelector('.quota');
+
+          if (quotaElement) {
+            const bytesPerGB = 1000 * 1000 * 1000;
+            const availableGB = ((quota.quota - quota.usage) / bytesPerGB).toFixed(2);
+            const totalGB = (quota.quota / bytesPerGB).toFixed(2);
+
+            quotaElement.innerHTML = `${availableGB} GB available <span>of ${totalGB} GB</span>`;
+          }
+        },
+      );
+    }
+  };
+
   const renderPage = async () => {
     // Should partial downloads also be visible here? For now - yes.
     // .filter((meta) => meta.done)
@@ -77,20 +99,10 @@ export default async (routerContext) => {
     }
 
     /**
-     * Display quota info.
+     * Display quota information and rerender it whenever IDB data changes.
      */
-    if (navigator.storage?.estimate) {
-      navigator.storage.estimate().then(
-        (quota) => {
-          const quotaElement = mainContent.querySelector('.quota');
-          const bytesPerGB = 1000 * 1000 * 1000;
-          const availableGB = ((quota.quota - quota.usage) / bytesPerGB).toFixed(2);
-          const totalGB = (quota.quota / bytesPerGB).toFixed(2);
-
-          quotaElement.innerHTML = `${availableGB} GB available <span>of ${totalGB} GB</span>`;
-        },
-      );
-    }
+    displayQuota();
+    window.addEventListener(IDB_DATA_CHANGED_EVENT, displayQuota);
   };
 
   /**


### PR DESCRIPTION
## Summary

**Issue:** The information displayed on Manage Downloads page is incorrect (hardcoded).

![image](https://user-images.githubusercontent.com/433570/111639772-d7ae5680-87fb-11eb-86da-6f0ff752b285.png)

**Solution:** Use the `StorageManager.estimate` method to retrieve correct values for the quota and used space in browsers that support it.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/web-dev-media/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/xwp/web-dev-media/ENGINEERING.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/xwp/web-dev-media/CONTRIBUTING.md) (updates are often made to the guidelines, check it out periodically).
