### PR TITLE
Add `video-content` wrapper for video content body

### DIFF
--- a/src/js/pages/Video.js
+++ b/src/js/pages/Video.js
@@ -84,13 +84,15 @@ export default (routerContext) => {
         </div>
         <div class="video-container--player"></div>
       </div>
-      <h2>${currentVideoData.title}</h2>
-      <div class="info">
-        <span class="date">${currentVideoData.date}</span> • <span class="length">${videoMinutes}min ${videoSeconds}sec</span>
+      <div class="video-content">
+        <h2>${currentVideoData.title}</h2>
+        <div class="info">
+          <span class="date">${currentVideoData.date}</span> • <span class="length">${videoMinutes}min ${videoSeconds}sec</span>
+        </div>
+        <p>${currentVideoData.description}</p>
+        <p><span class="downloader"></span></p>
+        ${currentVideoData.body}
       </div>
-      <p>${currentVideoData.description}</p>
-      <p><span class="downloader"></span></p>
-      ${currentVideoData.body}
     </article>
   </div>
 `;


### PR DESCRIPTION
## Summary

Adds a wrapper to the video page content to avoid any future side effects on the way the width is set on each element.

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/xwp/web-dev-media/ENGINEERING.md#tests).
- [x] My code follows the [Contributing Guidelines](https://github.com/xwp/web-dev-media/CONTRIBUTING.md) (updates are often made to the guidelines, check it out periodically).
