### PR TITLE
Schedule cron job to deploy staging every Monday at 6:20am

### DIFF
--- a/.github/workflows/cron-schedule.yaml
+++ b/.github/workflows/cron-schedule.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Daily
+name: Cron Schedule
 
 on:
   schedule:
-    - cron: '20 6 * * *'
+    - cron: '20 6 * * 1'
 
 jobs:
 


### PR DESCRIPTION
This ensures the staging environment never looses the dynamic URL on Firebase hosting.