### PR TITLE
Optimize the Rollup API & Cache generator plugins

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,17 +16,8 @@
 
 import css from 'rollup-plugin-import-css';
 import generateApi from './src/js/utils/generateApi.js';
-import generateAssetsToCache from './src/js/utils/generateAssetsToCache';
+import generateCache from './src/js/utils/generateCache';
 import json from '@rollup/plugin-json';
-
-async function setupApi() {
-  try {
-    const api = await generateApi();
-    await generateAssetsToCache(api);
-  } catch (err) {
-    console.error(err);
-  }
-}
 
 export default [
   {
@@ -36,7 +27,7 @@ export default [
       format: 'cjs',
     },
     plugins: [
-      setupApi(),
+      generateApi(),
       json(),
       css(),
     ],
@@ -48,7 +39,7 @@ export default [
       format: 'cjs',
     },
     plugins: [
-      setupApi(),
+      generateCache(),
     ],
   },
 ];

--- a/src/js/utils/generateApi.js
+++ b/src/js/utils/generateApi.js
@@ -83,19 +83,22 @@ const generateApiData = async () => {
 };
 
 /**
- * Generates the JSON API.
+ * Generates the public JSON API.
  *
- * @returns {object} The API object.
+ * @returns {object} The plugin configuration.
  */
-export default async function generateApi() {
-  const start = Date.now();
-  const apiData = await generateApiData();
-  const apiDataJSON = JSON.stringify(apiData, undefined, 2);
+export default function generateApi() {
+  return {
+    name: 'generate-api',
+    buildStart: async () => {
+      const start = Date.now();
+      const apiData = await generateApiData();
+      const apiDataJSON = JSON.stringify(apiData, undefined, 2);
 
-  fs.writeFile(apiDestFile, apiDataJSON, { encoding: 'utf-8' }, () => {
-    const time = Date.now() - start;
-    process.stdout.write(`\x1b[32mcreated \x1b[1m${apiDestFile}\x1b[22m in \x1b[1m${time}ms\x1b[22m\x1b[89m\n`);
-  });
-
-  return apiData;
+      fs.writeFile(apiDestFile, apiDataJSON, { encoding: 'utf-8' }, () => {
+        const time = Date.now() - start;
+        process.stdout.write(`\x1b[32mcreated \x1b[1m${apiDestFile}\x1b[22m in \x1b[1m${time}ms\x1b[22m\x1b[89m\n`);
+      });
+    },
+  };
 }

--- a/src/js/utils/generateCache.js
+++ b/src/js/utils/generateCache.js
@@ -40,34 +40,38 @@ async function* getFiles(dir) {
 /**
  * Generates the cached assets for the service worker.
  *
- * @param {object} api The video files API.
+ * @returns {object} The plugin configuration.
  */
-export default async function generateAssetsToCache(api) {
-  const start = Date.now();
-  const filesRegExp = /\.(html|css|js|svg|png|jpeg|jpg|ico)$/i;
-  const excludeFiles = ['sw.js', '404.html'];
-  const assetsToCache = ['/', '/api.json'];
-  const folder = 'public';
+export default function generateCache() {
+  return {
+    name: 'generate-cache',
+    buildStart: async () => {
+      const start = Date.now();
+      const api = JSON.parse(fs.readFileSync(`${process.cwd()}/public/api.json`, 'utf8'));
+      const filesRegExp = /\.(html|css|js|svg|png|jpeg|jpg|ico)$/i;
+      const excludeFiles = ['sw.js', '404.html'];
+      const assetsToCache = ['/', '/api.json'];
+      const folder = 'public';
 
-  // eslint-disable-next-line
-  for await (const file of getFiles(folder)) {
-    const fileName = path.basename(file);
-    const filePath = file.replace(`${process.cwd()}/${folder}`, '');
-    if (fileName.match(filesRegExp) && !excludeFiles.includes(fileName)) {
-      assetsToCache.push(filePath);
-    }
-  }
+      // eslint-disable-next-line
+      for await (const file of getFiles(folder)) {
+        const fileName = path.basename(file);
+        const filePath = file.replace(`${process.cwd()}/${folder}`, '');
+        if (fileName.match(filesRegExp) && !excludeFiles.includes(fileName)) {
+          assetsToCache.push(filePath);
+        }
+      }
 
-  // Add files from the API.
-  api.videos.forEach((video) => {
-    if (Array.isArray(video.thumbnail)) {
-      video.thumbnail.forEach((thumbnail) => assetsToCache.push(thumbnail.src));
-    } else if (Object.prototype.toString.call(video.thumbnail) === '[object String]') {
-      assetsToCache.push(video.thumbnail);
-    }
-  });
+      // Add files from the API.
+      api.videos.forEach((video) => {
+        if (Array.isArray(video.thumbnail)) {
+          video.thumbnail.forEach((thumbnail) => assetsToCache.push(thumbnail.src));
+        } else if (Object.prototype.toString.call(video.thumbnail) === '[object String]') {
+          assetsToCache.push(video.thumbnail);
+        }
+      });
 
-  const data = `/*
+      const data = `/*
 Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -85,8 +89,10 @@ limitations under the License.
 
 export default [\n  '${assetsToCache.join("',\n  '")}',\n];\n`;
 
-  fs.writeFile('src/js/sw/cache.js', data, () => {
-    const time = Date.now() - start;
-    process.stdout.write(`\x1b[32mcreated \x1b[1msrc/js/sw/cache.js\x1b[22m in \x1b[1m${time}ms\x1b[22m\x1b[89m\n`);
-  });
+      fs.writeFile('src/js/sw/cache.js', data, () => {
+        const time = Date.now() - start;
+        process.stdout.write(`\x1b[32mcreated \x1b[1msrc/js/sw/cache.js\x1b[22m in \x1b[1m${time}ms\x1b[22m\x1b[89m\n`);
+      });
+    },
+  };
 }


### PR DESCRIPTION
## Summary

The Rollup.js plugins to generate the `public/api.json` and `src/js/sw/cache.js` files were running twice due to a misconfiguration and a cross plugin dependency on `api.json`. The code was optimized and simplified to decouple the JSON API from the Service Worker Cache generation, making the area of responsibility for each plugin contained.
