### PR TITLE
Add meta description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <title>Kino</title>
+  <meta name="description" content="A sample video on demand (VOD) app to demonstrate media functionality in the context of a Progressive Web App.">
   <link rel="manifest" href="/manifest.json" />
   <link rel="shortcut icon" href="/images/favicon.ico">
   <link href=/images/favicon-32x32.png rel=icon sizes=32x32 type=image/png>


### PR DESCRIPTION
This PR adds missing `<meta name="description" ...>` as suggested by Lighthouse.

Issue: https://github.com/GoogleChrome/kino/issues/142