### PR TITLE
Add missing aria-label to buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
 <body>
 
 <header class="site-header" role="navigation">
-  <button class="site-header--hamburger-btn">
+  <button class="site-header--hamburger-btn" aria-label="Toggle menu">
     <svg class="site-header--hamburger-btn__open" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <g stroke="var(--text)">
         <path d="M10 12H21.8182" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/js/pages/Video.js
+++ b/src/js/pages/Video.js
@@ -78,7 +78,7 @@ export default (routerContext) => {
       <div class="video-container width-full">
         <div class="video-container--image">
           ${videoImageHTML}
-          <button class="play">
+          <button class="play" aria-label="Play video">
             <svg width="112" height="112" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
               <g filter="url(#filter0_d)">
                 <rect x="24" y="20.4863" width="64" height="64" rx="32" fill="white"/>

--- a/src/js/web-components/video-download/VideoDownloader.js
+++ b/src/js/web-components/video-download/VideoDownloader.js
@@ -295,7 +295,7 @@ export default class VideoDownloader extends HTMLElement {
         <span class="willremove">
           <button class="undo-remove" title="Undo deletion">Undo</button>
         </span>
-        <button class="ready">
+        <button class="ready" aria-label="Make available offline">
           <div class="tooltip">
             <svg class="icon icon--download" viewBox="0 0 27 27" width="27" height="27" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
               <path d="M7.304 25.416h11.56c4.026 0 6.552-2.852 6.552-6.888V7.638c0-4.036-2.512-6.888-6.552-6.888H7.304C3.265.75.752 3.602.752 7.638v10.89c0 4.036 2.514 6.888 6.554 6.888z" fill="" stroke="" stroke-width="1.5"/>


### PR DESCRIPTION
This PR adds missing `aria-label` to buttons as suggested by Lighthouse Accessibility section.

Issue: https://github.com/GoogleChrome/kino/issues/142