### PR TITLE
Fix contrast ratio

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -10,7 +10,7 @@
   --text: #BFBEC1;
   --logo: #E5E4E7;
   --icon: #F7F7F8;
-  --footer-text: #858287;
+  --footer-text: #5a585b;
   --accent-background: #12292B;
   --accent: #00C9DB;
   --accent-text: #fff;
@@ -36,7 +36,7 @@
     --text: #3D3B3F;
     --logo: #5F6368;
     --icon: #858287;
-    --footer-text: #858287;
+    --footer-text: #5a585b;
     --accent-background: #ECEFFF;
     --accent: #3740FF;
     --accent-text: #000;


### PR DESCRIPTION
This PR fixes contrast ratio issue raised by Lighthouse Accessibility section by using suggested color to pass AAA.

Issue: https://github.com/GoogleChrome/kino/issues/142