### PR TITLE
Add rel=noopener to external link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -98,7 +98,7 @@
             </clipPath>
           </defs>
         </svg>
-        <a target="_blank" href="https://github.com/GoogleChrome/kino/">See the source code</a>
+        <a target="_blank" rel="noopener" href="https://github.com/GoogleChrome/kino/">See the source code</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
This PR fixes security issue raised by Lighthouse by adding `rel=noopener` to the "See source code" external link.


Issue: https://github.com/GoogleChrome/kino/issues/142