### PR TITLE
Preconnect to https://storage.googleapis.com

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
   <link href=/images/safari-pinned-tab.svg rel=mask-icon color=#141216>
   <link rel="stylesheet" href="/styles.css">
   <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link rel="preconnect" href="https://storage.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,700&display=swap" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>


### PR DESCRIPTION
This PR makes sure https://storage.googleapis.com is added to the list of required origins to preconnect as suggested by Lighthouse.

Issue: https://github.com/GoogleChrome/kino/issues/142