### PR TITLE
Toggle footer visibility to improve CLS

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -388,11 +388,14 @@ h4,
 
 /* Site Footer */
 .site-footer {
-  display: block;
+  display: none;
   width: 100%;
   max-width: calc(1200px + var(--gutter) * 2);
   margin: 0 auto;
   border-top: 1px solid var(--separator);
+}
+.site-footer.visible {
+  display: block;
 }
 .site-footer .site-footer--content {
   color: var(--footer-text);

--- a/public/styles.css
+++ b/public/styles.css
@@ -388,14 +388,15 @@ h4,
 
 /* Site Footer */
 .site-footer {
-  display: none;
+  display: block;
   width: 100%;
   max-width: calc(1200px + var(--gutter) * 2);
   margin: 0 auto;
   border-top: 1px solid var(--separator);
+  opacity: 0;
 }
 .site-footer.visible {
-  display: block;
+  opacity: 1;
 }
 .site-footer .site-footer--content {
   color: var(--footer-text);

--- a/src/js/classes/Router.js
+++ b/src/js/classes/Router.js
@@ -78,6 +78,7 @@ export default class Router {
 
     this.context.apiData = apiData;
     this.context.mainContent = document.querySelector('main');
+    this.context.footer = document.querySelector('footer');
     this.context.navigate = this.navigate.bind(this);
 
     this.renderPage(window.location.href);
@@ -121,8 +122,10 @@ export default class Router {
     window.scrollTo(0, 0);
     this.context.path = targetUrl.pathname;
     this.context.mainContent.innerHTML = '';
+    this.context.footer.classList.toggle('visible', false);
     this.currentPage = targetUrl;
     foundRoute.callback(this.context);
+    this.context.footer.classList.toggle('visible', true);
   }
 
   /**


### PR DESCRIPTION
This PR improves drastically CLS by showing the `<footer>` only when main page content is rendered. It was flagged by Lighthouse (CLS goes from 0.31 to 0.005 now)

![image](https://user-images.githubusercontent.com/634478/132511338-e18daae9-63a4-43b6-8b11-8adfbc6503d7.png)
_Before_

![image](https://user-images.githubusercontent.com/634478/132511423-efe464b4-842b-465a-9758-3bac7aed4ad6.png)
_After_

Issue: https://github.com/GoogleChrome/kino/issues/142