### PR TITLE
Add syntax highlighting to code samples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3768,6 +3768,12 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-jsdoc": "^35.0.0",
     "front-matter": "^4.0.2",
+    "highlight.js": "^11.2.0",
     "husky": "^6.0.0",
     "jest": "^27.0.3",
     "marked": "^2.0.6",

--- a/public/styles.css
+++ b/public/styles.css
@@ -822,3 +822,86 @@ button.delete-all:hover svg path {
     justify-self: center;
   }
 }
+
+/*
+ * Google Code style
+ */
+.hljs {
+  background: white;
+  color: black;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #800;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-section,
+.hljs-title,
+.hljs-name {
+  color: #008;
+}
+
+.hljs-variable,
+.hljs-template-variable {
+  color: #660;
+}
+
+.hljs-string,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-regexp {
+  color: #080;
+}
+
+.hljs-literal,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-meta,
+.hljs-number,
+.hljs-link {
+  color: #066;
+}
+
+.hljs-title,
+.hljs-doctag,
+.hljs-type,
+.hljs-attr,
+.hljs-built_in,
+.hljs-params {
+  color: #606;
+}
+
+.hljs-attribute,
+.hljs-subst {
+  color: #000;
+}
+
+.hljs-formula {
+  background-color: #eee;
+  font-style: italic;
+}
+
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #9B703F
+}
+
+.hljs-addition {
+  background-color: #baeeba;
+}
+
+.hljs-deletion {
+  background-color: #ffc8bd;
+}
+
+.hljs-doctag,
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -25,6 +25,24 @@
   --code-border: #3D3B3F;
   --code-do: #00CC63;
   --code-dont: #FF375C;
+  --hljs-color-1: #c9d1d9;
+  --hljs-color-2: #0d1117;
+  --hljs-color-3: #ff7b72;
+  --hljs-color-4: #d2a8ff;
+  --hljs-color-5: #79c0ff;
+  --hljs-color-6: #a5d6ff;
+  --hljs-color-7: #ffa657;
+  --hljs-color-8: #8b949e;
+  --hljs-color-9: #7ee787;
+  --hljs-color-10: #c9d1d9;
+  --hljs-color-11: #1f6feb;
+  --hljs-color-12: #f2cc60;
+  --hljs-color-13: #c9d1d9;
+  --hljs-color-14: #c9d1d9;
+  --hljs-color-15: #aff5b4;
+  --hljs-color-16: #033a16;
+  --hljs-color-17: #ffdcd7;
+  --hljs-color-18: #67060c;
 }
 
 @media (prefers-color-scheme: light) {
@@ -49,6 +67,24 @@
     --toggle-background-on: #3740FF;
     --code-background: #F7F7F8;
     --code-border: #E6E4E7;
+    --hljs-color-1: #24292e;
+    --hljs-color-2: #ffffff;
+    --hljs-color-3: #d73a49;
+    --hljs-color-4: #6f42c1;
+    --hljs-color-5: #005cc5;
+    --hljs-color-6: #032f62;
+    --hljs-color-7: #e36209;
+    --hljs-color-8: #6a737d;
+    --hljs-color-9: #22863a;
+    --hljs-color-10: #24292e;
+    --hljs-color-11: #005cc5;
+    --hljs-color-12: #735c0f;
+    --hljs-color-13: #24292e;
+    --hljs-color-14: #24292e;
+    --hljs-color-15: #22863a;
+    --hljs-color-16: #f0fff4;
+    --hljs-color-17: #b31d28;
+    --hljs-color-18: #ffeef0;
   }
 }
 
@@ -824,84 +860,96 @@ button.delete-all:hover svg path {
 }
 
 /*
- * Google Code style
+ * Highlight.js style
  */
 .hljs {
-  background: white;
-  color: black;
+  color: var(--hljs-color-1);
+  background: var(--hljs-color-2);
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: var(--hljs-color-3);
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  color: var(--hljs-color-4);
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: var(--hljs-color-5);
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  color: var(--hljs-color-6);
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  color: var(--hljs-color-7);
 }
 
 .hljs-comment,
-.hljs-quote {
-  color: #800;
-}
-
-.hljs-keyword,
-.hljs-selector-tag,
-.hljs-section,
-.hljs-title,
-.hljs-name {
-  color: #008;
-}
-
-.hljs-variable,
-.hljs-template-variable {
-  color: #660;
-}
-
-.hljs-string,
-.hljs-selector-attr,
-.hljs-selector-pseudo,
-.hljs-regexp {
-  color: #080;
-}
-
-.hljs-literal,
-.hljs-symbol,
-.hljs-bullet,
-.hljs-meta,
-.hljs-number,
-.hljs-link {
-  color: #066;
-}
-
-.hljs-title,
-.hljs-doctag,
-.hljs-type,
-.hljs-attr,
-.hljs-built_in,
-.hljs-params {
-  color: #606;
-}
-
-.hljs-attribute,
-.hljs-subst {
-  color: #000;
-}
-
+.hljs-code,
 .hljs-formula {
-  background-color: #eee;
-  font-style: italic;
+  color: var(--hljs-color-8);
 }
 
-.hljs-selector-id,
-.hljs-selector-class {
-  color: #9B703F
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  color: var(--hljs-color-9);
 }
 
-.hljs-addition {
-  background-color: #baeeba;
+.hljs-subst {
+  color: var(--hljs-color-10);
 }
 
-.hljs-deletion {
-  background-color: #ffc8bd;
-}
-
-.hljs-doctag,
-.hljs-strong {
+.hljs-section {
+  color: var(--hljs-color-11);
   font-weight: bold;
 }
 
+.hljs-bullet {
+  color: var(--hljs-color-12);
+}
+
 .hljs-emphasis {
+  color: var(--hljs-color-13);
   font-style: italic;
+}
+
+.hljs-strong {
+  color: var(--hljs-color-14);
+  font-weight: bold;
+}
+
+.hljs-addition {
+  color: var(--hljs-color-15);
+  background-color: var(--hljs-color-16);
+}
+
+.hljs-deletion {
+  color: var(--hljs-color-17);
+  background-color: var(--hljs-color-18);
 }

--- a/src/api/basics/01-single-video.md
+++ b/src/api/basics/01-single-video.md
@@ -27,7 +27,7 @@ video and `AAC` audio.
 
 ### Basic code example
 
-```
+```html
 <video controls>
   <source src="video.mp4" type="video/mp4">
 </video>

--- a/src/api/basics/02-multiple-sources.md
+++ b/src/api/basics/02-multiple-sources.md
@@ -39,7 +39,7 @@ one to play.
 
 ### Basic code example
 
-```
+```html
 <video>
   <source src="av1.mp4" type="video/mp4; codecs=\"av01.0.04M.08\"">
   <source src="hevc.mp4" type="video/mp4; codecs=\"hvc1\"">

--- a/src/api/basics/03-using-webvtt.md
+++ b/src/api/basics/03-using-webvtt.md
@@ -36,7 +36,7 @@ information.
 
 ### Basic code example
 
-```
+```html
 <video controls>
   <source src="av1.mp4" type="video/mp4; codecs=\"av01.0.05M.08\"">
   <source src="hevc.mp4" type="video/mp4; codecs=\"hvc1\"">
@@ -79,7 +79,7 @@ interval definitions. Another handy feature is the ability to style individual
 cues using CSS. Perhaps you want to use a yellow text color, and a
 semi-transparent background for all captions.
 
-```
+```html
 <style>
   ::cue {
     color: yellow;

--- a/src/api/streaming/04-streaming-basics.md
+++ b/src/api/streaming/04-streaming-basics.md
@@ -62,7 +62,7 @@ native [support for HLS] playback, browsers generally [don't support native DASH
 stream playback. This means often it's not enough to simply point the `<source>`
 in the `<video>` element to a manifest file.
 
-```
+```html
 <video controls>
   <source src="manifest.mpd" type="application/dash+xml">
 </video>
@@ -94,7 +94,7 @@ it play back whatever media data is pumped into the buffers attached to the
 
 ### Basic code example
 
-```
+```js
 const videoEl = document.querySelector('video');
 const mediaSource = new MediaSource();
 

--- a/src/js/utils/generateApi.js
+++ b/src/js/utils/generateApi.js
@@ -22,9 +22,17 @@ const fs = require('fs');
 const path = require('path');
 const frontMatter = require('front-matter');
 const marked = require('marked');
+const hljs = require('highlight.js');
 
 const apiSrcPath = 'src/api/';
 const apiDestFile = 'public/api.json';
+
+marked.setOptions({
+  highlight: (code, lang) => {
+    const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+    return hljs.highlight(code, { language }).value;
+  },
+});
 
 /**
  * Iterator to recursively find all files in a given directory.


### PR DESCRIPTION
This PR adds some code syntax highlighting to code samples with the help of the "highlight.js" package. It makes code samples more readable.

![image](https://user-images.githubusercontent.com/634478/132533212-19b31e09-0eae-442d-86bb-27c7a60df3c6.png)
_Before_

![image](https://user-images.githubusercontent.com/634478/132533265-d2dd2a81-5102-4086-933e-cc4fb30ef57c.png)
_After_

Fixes https://github.com/GoogleChrome/kino/issues/143
