### PR TITLE
Specify firebase hosting feature in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ Login to Firebase:
 
 Initialize Firebase:
 
-    firebase init
+    firebase init hosting
+
+Answer questions as follows:
+
+    ? What do you want to use as your public directory? public
+    ? Configure as a single-page app (rewrite all urls to /index.html)? Yes
+    ? Set up automatic builds and deploys with GitHub? No
+    ? File public/index.html already exists. Overwrite? No
 
 Install the dependencies:
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,14 +1,16 @@
 {
   "hosting": {
     "public": "public",
-    "rewrites": [{
-      "source": "**",
-      "destination": "/index.html"
-    }],
     "ignore": [
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
     ]
   }
 }


### PR DESCRIPTION
As discussed in https://github.com/GoogleChrome/kino/issues/157, this PR improves `firebase init` command in README.md file by specifying the firebase hosting feature and updating accordingly the `firebase.json` file.

Fixes https://github.com/GoogleChrome/kino/issues/157
