### PR TITLE
Fix download component behavior when network connection is cut.

### DIFF
--- a/src/js/classes/DownloadManager.js
+++ b/src/js/classes/DownloadManager.js
@@ -131,7 +131,15 @@ export default class DownloadManager {
       };
     }
 
-    const response = await fetch(downloadUrl, fetchOpts);
+    let response;
+    try {
+      response = await fetch(downloadUrl, fetchOpts);
+    } catch (e) {
+      this.warning(`Pausing the download of ${downloadUrl} due to network error.`);
+      this.forcePause();
+      return;
+    }
+
     const reader = response.body.getReader();
     const mimeType = response.headers.get('Content-Type') || getMimeByURL(url);
     const fileLength = response.headers.has('Content-Range')
@@ -143,8 +151,13 @@ export default class DownloadManager {
 
     let dataChunk;
     do {
-      /* eslint-disable-next-line no-await-in-loop */
-      dataChunk = await reader.read();
+      try {
+        /* eslint-disable-next-line no-await-in-loop */
+        dataChunk = await reader.read();
+      } catch (e) {
+        this.warning(`Pausing the download of ${downloadUrl} due to network error.`);
+        this.forcePause();
+      }
 
       if (!dataChunk.done) this.buffer.add(dataChunk.value);
     } while (dataChunk && !dataChunk.done && !this.paused);
@@ -158,6 +171,26 @@ export default class DownloadManager {
    */
   pause() {
     this.paused = true;
+  }
+
+  /**
+   * Pauses the current download and forces the associated
+   * `VideoDownloader` instance to render the paused UI, too.
+   */
+  forcePause() {
+    this.pause();
+    this.internal.videoDownloader.downloading = false;
+  }
+
+  /**
+   * Handle a warning message.
+   *
+   * @todo Update to expose the warning to the user.
+   * @param {string} message Error message.
+   */
+  warning(message) {
+    /* eslint-disable-next-line no-console */
+    console.warn(message);
   }
 
   /**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue(s) this PR fixes. -->
Fixes #126 

Currently when network connection is lost while a video is being downloaded, the downloader component gets stuck and doesn't either explicitly pause the download or wait for the connection to come back up and resume automatically.

To address this, this PR makes sure that when there is a connection related error encountered by the `DownloadManager`, the current downloads are paused automatically and the UI of the downloader component changes from the "downloading" state to "paused". At the same time a console warning is generated. User can then manually resume the affected downloads once connection is restored.

While this is likely not a perfect solution, it may be good enough or may serve as a first step towards a more robust solution. Please let me know your thoughts, @derekherman and / or @beaufortfrancois.

### Screencast of the updated behavior

https://user-images.githubusercontent.com/433570/136422299-5d7559c5-2e71-4847-80f8-7352a619c1f3.mp4
