### PR TITLE
Use Playback APIs to select appropriate media sources

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -646,6 +646,8 @@ article pre,
 .has-overlay .video-container--overlay > * {
   grid-column: 1;
   grid-row: 1;
+  max-width: 100%;
+  height: auto;
 }
 .has-overlay .video-container--overlay button {
   color: var(--accent);

--- a/src/js/classes/Streamer.js
+++ b/src/js/classes/Streamer.js
@@ -676,7 +676,7 @@ export default class {
 
     /**
      * In case the internal counter used by `getVideoPlaybackQuality` resets
-     * for any reason, we need to makes sure our latest numbers are never
+     * for any reason, we need to make sure our latest numbers are never
      * higher than what we're returned.
      */
     const droppedFramesSinceLastSample = (

--- a/src/js/classes/Streamer.js
+++ b/src/js/classes/Streamer.js
@@ -33,7 +33,7 @@ export default class {
       media: {
         baseURL: '/',
         streamTypes: [],
-        representations: selectRepresentations(parser, opts),
+        representations: [],
         lastRepresentationsIds: {},
         lastRepresentationSwitch: 0,
         duration: this.parser.duration,
@@ -54,8 +54,6 @@ export default class {
       },
     };
 
-    // Iterate which stream types we have separate representations for.
-    this.stream.media.streamTypes = Object.keys(this.stream.media.representations);
     this.stream.media.baseURL = parser.baseURL;
 
     /**
@@ -97,9 +95,21 @@ export default class {
   }
 
   /**
+   * Figures out which representations are best to be used on a current device.
+   */
+  async initializeRepresentations() {
+    this.stream.media.representations = await selectRepresentations(this.parser, this.opts);
+
+    // Iterate which stream types we have separate representations for.
+    this.stream.media.streamTypes = Object.keys(this.stream.media.representations);
+  }
+
+  /**
    * Initializes all the differents parts of the stream.
    */
   async initializeStream() {
+    await this.initializeRepresentations();
+
     /**
      * Create and attach a `MediaSource` element.
      *

--- a/src/js/utils/getDecodingInfo.js
+++ b/src/js/utils/getDecodingInfo.js
@@ -9,19 +9,14 @@ export default async function getDecodingInfo(configuration) {
     return navigator.mediaCapabilities.decodingInfo(configuration);
   }
 
-  // If we can't use the Media Capabilities API, try using `canPlayType`.
-  try {
-    const videoEl = document.createElement('video');
-    const typeString = configuration.audio.contentType || configuration.video.contentType;
-    const canPlay = videoEl.canPlayType(typeString);
-
+  // If we can't use the Media Capabilities API, try using `MediaSource.isTypeSupported`.
+  if (MediaSource && MediaSource.isTypeSupported) {
+    const contentType = configuration.video?.contentType || configuration.audio?.contentType;
     return {
-      supported: canPlay === 'probably' || canPlay === 'maybe',
+      supported: MediaSource.isTypeSupported(contentType),
       smooth: false,
       powerEfficient: false,
     };
-  } catch (error) {
-    // Fail quietly.
   }
 
   // Very unlikely any agent would reach this point, but

--- a/src/js/utils/getDecodingInfo.js
+++ b/src/js/utils/getDecodingInfo.js
@@ -1,0 +1,34 @@
+/**
+ * Returns decoding info for a given media configuration.
+ *
+ * @param {MediaDecodingConfiguration} configuration Media configuration.
+ * @returns {Promise<MediaCapabilitiesInfo>} Media decoding information.
+ */
+export default async function getDecodingInfo(configuration) {
+  if (navigator.mediaCapabilities) {
+    return navigator.mediaCapabilities.decodingInfo(configuration);
+  }
+
+  // If we can't use the Media Capabilities API, try using `canPlayType`.
+  try {
+    const videoEl = document.createElement('video');
+    const typeString = configuration.audio.contentType || configuration.video.contentType;
+    const canPlay = videoEl.canPlayType(typeString);
+
+    return {
+      supported: canPlay === 'probably' || canPlay === 'maybe',
+      smooth: false,
+      powerEfficient: false,
+    };
+  } catch (error) {
+    // Fail quietly.
+  }
+
+  // Very unlikely any agent would reach this point, but
+  // if all fails, pretend we support the source.
+  return {
+    supported: true,
+    smooth: false,
+    powerEfficient: false,
+  };
+}

--- a/src/js/utils/getMediaConfiguration.js
+++ b/src/js/utils/getMediaConfiguration.js
@@ -1,0 +1,76 @@
+import getRepresentationMimeString from './getRepresentationMimeString';
+
+/**
+ * Returns a Media configuration object for a given
+ * stream video representation.
+ *
+ * @param {object} representation MPEG DASH representation data.
+ * @param {string} representation.bandwidth Video bandwidth.
+ * @param {string} representation.codecs    Codecs string.
+ * @param {string} representation.frameRate Framerate info.
+ * @param {string} representation.height    Video height in pixels.
+ * @param {string} representation.mimeType  Video MIME.
+ * @param {string} representation.width     Video width in pixels.
+ * @returns {MediaConfiguration} Media configuration object.
+ */
+export function getMediaConfigurationVideo(representation) {
+  /**
+   * Framerate can be specified as `frameRate: "24000/1001"` in the representation.
+   *
+   * We need to convert it to a float.
+   */
+  const framerateChunks = representation.frameRate.split('/');
+  let framerate = parseFloat(representation.frameRate);
+
+  if (framerateChunks.length === 2) {
+    framerate = parseFloat(framerateChunks[0]) / parseFloat(framerateChunks[1]);
+  }
+
+  return {
+    type: 'file',
+    video: {
+      contentType: getRepresentationMimeString(representation),
+      width: parseInt(representation.width, 10),
+      height: parseInt(representation.height, 10),
+      bitrate: parseInt(representation.bandwidth, 10),
+      framerate,
+    },
+  };
+}
+
+/**
+ * Returns a Media configuration object for a given
+ * stream audio representation.
+ *
+ * @param {object}  representation                   MPEG DASH representation data.
+ * @param {string}  representation.bandwidth         Audio bandwidth.
+ * @param {string}  representation.codecs            Codecs string.
+ * @param {string}  representation.audioSamplingRate Audio sampling rate.
+ * @param {string}  representation.mimeType          Audio MIME.
+ * @param {Element} representation.element           Representation XML node.
+ * @returns {MediaConfiguration} Media configuration object.
+ */
+export function getMediaConfigurationAudio(representation) {
+  /**
+   * Sensible default, but we'll try to find out the actual value.
+   */
+  let channels = 2;
+
+  if (representation.element) {
+    const acc = representation.element.querySelector('AudioChannelConfiguration');
+
+    if (acc) {
+      channels = parseInt(acc.getAttribute('value'), 10);
+    }
+  }
+
+  return {
+    type: 'file',
+    audio: {
+      contentType: getRepresentationMimeString(representation),
+      bitrate: parseInt(representation.bandwidth, 10),
+      samplerate: parseInt(representation.audioSamplingRate, 10),
+      channels,
+    },
+  };
+}

--- a/src/js/utils/getMediaConfiguration.js
+++ b/src/js/utils/getMediaConfiguration.js
@@ -27,7 +27,7 @@ export function getMediaConfigurationVideo(representation) {
   }
 
   return {
-    type: 'file',
+    type: 'media-source',
     video: {
       contentType: getRepresentationMimeString(representation),
       width: parseInt(representation.width, 10),
@@ -65,7 +65,7 @@ export function getMediaConfigurationAudio(representation) {
   }
 
   return {
-    type: 'file',
+    type: 'media-source',
     audio: {
       contentType: getRepresentationMimeString(representation),
       bitrate: parseInt(representation.bandwidth, 10),


### PR DESCRIPTION
## Summary

Uses the [Media Capabilities API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Capabilities_API) and [Video Playback Quality API](https://developer.mozilla.org/en-US/docs/Web/API/VideoPlaybackQuality) to gain insights into the projected and actual video playback performance and to select such video representation from the list of available sources that will lead to the most efficient and smooth playback.

### Media Capabilities API usage

* Updated the `selectRepresentations` method to take the information provided by Media Capabilities API into account.
* The video suitable for playback is no longer determined only by the browser being able to play the video format, but it more directly depends on information returned by Media Capabilities API.
* By default only those sources that are reported as `supported`, `smooth` and `powerEfficient` are taken into consideration when selecting a source.
* If no such sources exist, we'll try to pick from sources that are `supported` and `smooth`.
* And only if no such sources exist, we'll only consider sources that are `supported`.

### Video Playback Quality API usage

The application currently adapts to changing network conditions and is able to dynamically swap video sources for a source with a lower bitrate in cases when the available bandwidth is too small.

I've updated the implementation to also take the Video Playback Quality data into account.

If we're consistently dropping frames, the application will try to load a video with a lower bitrate. The implicit assumption here being that less data ~ less pixels ~ more frames rendered. This assumption should be correct in the context of the Kino app, because once we choose a video format initially, we stick with it.