### PR TITLE
Fix download auto-pausing when network is cut

### DIFF
--- a/src/js/classes/DownloadManager.js
+++ b/src/js/classes/DownloadManager.js
@@ -226,7 +226,11 @@ export default class DownloadManager {
    */
   forcePause() {
     this.pause();
-    this.internal.videoDownloader.downloading = false;
+
+    if (document) {
+      const pauseEvent = new CustomEvent('pausedownload', { detail: this.videoId });
+      document.dispatchEvent(pauseEvent);
+    }
   }
 
   /**

--- a/src/js/classes/VideoDownloaderRegistry.js
+++ b/src/js/classes/VideoDownloaderRegistry.js
@@ -27,6 +27,10 @@ export default class VideoDownloaderRegistry {
   constructor({ connectionStatus }) {
     this.instances = new Map();
     this.connectionStatus = connectionStatus;
+
+    if (document) {
+      document.addEventListener('pausedownload', this.onPauseDownload.bind(this));
+    }
   }
 
   /**
@@ -66,5 +70,19 @@ export default class VideoDownloaderRegistry {
    */
   destroyAll() {
     this.instances.clear();
+  }
+
+  /**
+   * When a pause request is received, we need to pause the download.
+   *
+   * @param {CustomEvent} e Pause event.
+   * @param {string} e.detail Video ID.
+   */
+  onPauseDownload(e) {
+    const downloaderInstance = this.get(e.detail);
+
+    if (downloaderInstance) {
+      downloaderInstance.downloading = false;
+    }
   }
 }


### PR DESCRIPTION
## Summary

The `DownloadManager` no longer has direct access to an associated `videoDownloader` instance after the changes requires to support the Background Fetch API.

We now use a custom event to signal a pause intent and when we're in a `document` context, we allow the `VideoDownloaderRegistry` instance to listen to these events and to direct them to the appropriate `videoDownloader` instances allowing them to change their UI to display a paused state.

<!-- Please reference the issue(s) this PR fixes. -->
Fixes #176
