### PR TITLE
Only play one video in PiP at once.

### DIFF
--- a/src/js/web-components/video-player/VideoPlayer.js
+++ b/src/js/web-components/video-player/VideoPlayer.js
@@ -27,7 +27,7 @@ import {
   PIP_CLASSNAME,
 } from '../../constants';
 
-export default class extends HTMLElement {
+export default class VideoPlayer extends HTMLElement {
   /**
    * @param {VideoDownloader} downloader Video downloader associated with the current video.
    */
@@ -464,6 +464,11 @@ export default class extends HTMLElement {
       pipButton.disabled = true;
       try {
         if (this !== document.pictureInPictureElement) {
+          // If another video is already in PiP, pause it and exit PiP mode.
+          if (document.pictureInPictureElement instanceof VideoPlayer) {
+            document.pictureInPictureElement.videoElement.pause();
+            await document.exitPictureInPicture();
+          }
           await this.videoElement.requestPictureInPicture();
         } else {
           await document.exitPictureInPicture();

--- a/src/js/web-components/video-player/VideoPlayer.js
+++ b/src/js/web-components/video-player/VideoPlayer.js
@@ -464,7 +464,7 @@ export default class VideoPlayer extends HTMLElement {
       pipButton.disabled = true;
       try {
         if (this !== document.pictureInPictureElement) {
-          // If another video is already in PiP, pause it and exit PiP mode.
+          // If another video is already in PiP, pause it.
           if (document.pictureInPictureElement instanceof VideoPlayer) {
             document.pictureInPictureElement.videoElement.pause();
           }

--- a/src/js/web-components/video-player/VideoPlayer.js
+++ b/src/js/web-components/video-player/VideoPlayer.js
@@ -467,7 +467,6 @@ export default class VideoPlayer extends HTMLElement {
           // If another video is already in PiP, pause it and exit PiP mode.
           if (document.pictureInPictureElement instanceof VideoPlayer) {
             document.pictureInPictureElement.videoElement.pause();
-            await document.exitPictureInPicture();
           }
           await this.videoElement.requestPictureInPicture();
         } else {


### PR DESCRIPTION
## Summary

When initializing the PiP experience, make sure no other video is playing. If it is, exit that PiP experience first and pause the previously playing video before opening a new PiP window.

<!-- Please reference the issue(s) this PR fixes. -->
Fixes #106 #178 
